### PR TITLE
fix: getFeedUrl 함수에서 키워드의 URL 인코딩 오류 수정

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -94,15 +94,16 @@ function getFeedUrl(keyword, startup) {
 
   // 뉴스 검색결과 정렬 옵션 (미지정시 기본값 date(날짜순), 이외에 sim(유사도순) 지정 가능하나 비추천)
   const sort = "date";
+  
+  // 키워드 매개변수를 URL에서 올바르게 표현하기 위해 URL 인코딩합니다.
+  const encodedKeyword = encodeURIComponent(keyword);
 
   // 뉴스봇을 최초로 실행한 경우에는 피드 체크 용도로 위의 설정값과 무관하게 가장 최신의 1개 뉴스만 전송한다.
   if (startup) {
-    return "https://openapi.naver.com/v1/search/news.xml?query=" + keyword + "&display=1&start=1&sort=date";
+    return "https://openapi.naver.com/v1/search/news.xml?query=" + encodedKeyword + "&display=1&start=1&sort=date";
   }
-
-  return "https://openapi.naver.com/v1/search/news.xml?query=" + keyword + "&display=" + display + "&start=" + start + "&sort=" + sort;
-  
-}
+  return "https://openapi.naver.com/v1/search/news.xml?query=" + encodedKeyword + "&display=" + display + "&start=" + start + "&sort=" + sort;
+  }
 
 
 function getFeed(keyword, clientId, clientSecret, startup=false) {


### PR DESCRIPTION
getFeedUrl 함수의 URL 인코딩 문제를 수정합니다. 이전에는 키워드 매개변수가 피드 URL 구성 전에 올바르게 인코딩되지 않아 잘못된 검색 결과 또는 API 요청 시 오류가 발생할 수 있었습니다. 이 수정은 키워드를 encodeURIComponent를 사용하여 올바르게 인코딩하도록 보정합니다. 이제 구성된 피드 URL은 Naver Open API 요청에서 키워드를 정확하게 나타내며, 뉴스 기사에 대한 정확하고 일관된 검색 결과를 보장합니다.